### PR TITLE
PosterSwitcher: simplify by splitting

### DIFF
--- a/src/components/PosterInformation.vue
+++ b/src/components/PosterInformation.vue
@@ -20,13 +20,6 @@
           </a>
         </span>
         <span class="my-3">
-          <button
-            type="button"
-            class="px-3 py-1 rounded-lg border bg-blue-700 border-blue-700 text-white hover:bg-blue-900"
-            @click="close"
-          >
-            Close
-          </button>
         </span>
       </div>
       <div class="w-1/4">
@@ -45,13 +38,13 @@
       :class="{
         'border-4 border-teal-400': selected
       }"
-      @click="onSelect(poster)"
+      @click="select(poster)"
     />
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from "vue-property-decorator";
+import { Component, Emit, Prop, Vue } from "vue-property-decorator";
 import { Poster } from "../poster";
 import { Orientation } from "../orientation";
 
@@ -61,14 +54,17 @@ import { Orientation } from "../orientation";
 export default class PosterInformation extends Vue {
   @Prop()
   poster!: Poster;
+
   @Prop({ default: false })
   selected!: boolean;
-  @Prop()
+
+  @Prop({ default: false })
   frameRotated!: boolean;
-  @Prop()
-  onSelect!: Function;
-  @Prop()
-  close!: Function;
+
+  @Emit("select")
+  select(poster: Poster): void {
+    undefined;
+  }
 
   get rotate(): boolean {
     return this.frameRotated && this.poster.orientation === Orientation.Both;

--- a/src/components/PosterSwitcher.vue
+++ b/src/components/PosterSwitcher.vue
@@ -1,20 +1,65 @@
 <template>
   <Modal name="poster-switcher" :open="open" @close="close">
     <template v-slot:title>
-      <h2 class="text-l font-semibold mr-2">Change poster</h2>
-      <span>Select a poster by clicking it.</span>
+      <div v-if="formMode" class="flex flex-row flex-wrap justify-between border-b border-gray-600">
+        <div class="mr-6 mb-4">
+          <h2 class="text-l font-semibold mr-2">Change poster - add one</h2>
+        </div>
+        <div class="flex flex-row justify-between mb-4">
+          <button
+            class="p-2 ml-1 border rounded border-gray-800 bg-white mr-2 hover:bg-gray-800 hover:border-gray-300 hover:text-white"
+            @click="formMode = false"
+          >
+            Choose poster instead
+          </button>
+          <button
+            type="button"
+            class="p-2 ml-1 rounded border bg-blue-700 border-blue-700 text-white hover:bg-blue-900"
+            @click="close"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+      <div v-else class="flex flex-row flex-wrap justify-between border-b border-gray-600">
+        <div class="mr-6 mb-4">
+          <h2 class="text-l font-semibold mr-2">Change poster - pick one</h2>
+        </div>
+        <div class="flex flex-row justify-between mb-4">
+          <button
+            class="p-2 ml-1 border rounded border-gray-800 bg-white mr-2 hover:bg-gray-800 hover:border-gray-300 hover:text-white"
+            @click="formMode = true"
+          >
+            + Add a poster
+          </button>
+          <button
+            type="button"
+            class="p-2 ml-1 rounded border bg-blue-700 border-blue-700 text-white hover:bg-blue-900"
+            @click="close"
+          >
+            Close
+          </button>
+        </div>
+      </div>
     </template>
     <template v-slot:body>
-      <div class="flex flex-wrap">
+      <div v-if="formMode" class="flex flex-wrap pt-2">
         <PosterForm :poster="newPoster" :on-submit="onSubmitPoster" />
+      </div>
+      <div v-if="!formMode" class="flex flex-wrap">
+        <PosterInformation
+          v-if="selectedPoster != null"
+          :poster="selectedPoster"
+          :selected="true"
+          :frame-rotated="rotated"
+        />
+
         <PosterInformation
           v-for="poster in posters"
           :key="poster.id"
           :poster="poster"
-          :selected="selected(poster)"
           :frame-rotated="rotated"
-          :on-select="onSelectPoster"
-          :close="close"
+          @select="onSelectPoster"
         />
       </div>
     </template>
@@ -53,12 +98,10 @@ export default class PosterSwitcher extends Vue {
   selectedPoster: Poster | null = null;
   newPoster: Poster | null = new Poster(0, "", "", "");
 
+  formMode = false;
+
   get rotated(): boolean {
     return this.frame && this.frame.orientation === Orientation.Landscape;
-  }
-
-  selected(poster: Poster): boolean {
-    return this.selectedPoster !== null && poster.id === this.selectedPoster.id;
   }
 
   @Emit("close")
@@ -71,8 +114,8 @@ export default class PosterSwitcher extends Vue {
     undefined;
   }
 
-  @Watch('frame')
-  onPropertyChanged(value: Frame | null, oldValue: Frame | null) {
+  @Watch("frame")
+  onPropertyChanged(value: Frame | null, oldValue: Frame | null): void {
     if (this.frame === null) {
       this.selectedPoster = null;
     } else {


### PR DESCRIPTION
- Picking a new poster or adding a new poster now uses separate views.
- Always render the selected poster on the top.